### PR TITLE
Add sts role based authentication to the dynamodb connector

### DIFF
--- a/airbyte-integrations/connectors/source-dynamodb/src/main/java/io/airbyte/integrations/source/dynamodb/DynamodbConfig.java
+++ b/airbyte-integrations/connectors/source-dynamodb/src/main/java/io/airbyte/integrations/source/dynamodb/DynamodbConfig.java
@@ -20,6 +20,8 @@ public record DynamodbConfig(
 
                              String secretKey,
 
+                             String roleArn,
+
                              List<String> reservedAttributeNames,
 
                              boolean ignoreMissingPermissions
@@ -30,6 +32,7 @@ public record DynamodbConfig(
     JsonNode credentials = jsonNode.get("credentials");
     JsonNode accessKeyId = credentials.get("access_key_id");
     JsonNode secretAccessKey = credentials.get("secret_access_key");
+    JsonNode roleArn = credentials.get("role_arn");
 
     JsonNode endpoint = jsonNode.get("endpoint");
     JsonNode region = jsonNode.get("region");
@@ -40,6 +43,7 @@ public record DynamodbConfig(
         region != null && !region.asText().isBlank() ? Region.of(region.asText()) : null,
         accessKeyId != null && !accessKeyId.asText().isBlank() ? accessKeyId.asText() : null,
         secretAccessKey != null && !secretAccessKey.asText().isBlank() ? secretAccessKey.asText() : null,
+        roleArn != null && !roleArn.asText().isBlank() ? roleArn.asText() : null,
         attributeNames != null ? Arrays.asList(attributeNames.asText().split("\\s*,\\s*")) : List.of(),
         missingPermissions != null ? missingPermissions.asBoolean() : false);
   }

--- a/airbyte-integrations/connectors/source-dynamodb/src/main/java/io/airbyte/integrations/source/dynamodb/DynamodbUtils.java
+++ b/airbyte-integrations/connectors/source-dynamodb/src/main/java/io/airbyte/integrations/source/dynamodb/DynamodbUtils.java
@@ -24,6 +24,9 @@ import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.sts.StsClient;
+import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider;
+import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
 
 public class DynamodbUtils {
 
@@ -40,8 +43,26 @@ public class DynamodbUtils {
       LOGGER.info("Creating credentials using access key and secret key");
       AwsCredentials awsCreds = AwsBasicCredentials.create(dynamodbConfig.accessKey(), dynamodbConfig.secretKey());
       awsCredentialsProvider = StaticCredentialsProvider.create(awsCreds);
+    } else if (!StringUtils.isBlank(dynamodbConfig.roleArn())) {
+      LOGGER.info("Using Role Based Access with provided role ARN");
+
+      AssumeRoleRequest assumeRoleRequest = AssumeRoleRequest.builder()
+        .roleArn(dynamodbConfig.roleArn())
+        .roleSessionName("airbyte-source-dynamodb")
+        .build();
+
+      StsClient stsClient = StsClient.builder()
+        .region(dynamodbConfig.region())
+        .build();
+
+      StsAssumeRoleCredentialsProvider provider = StsAssumeRoleCredentialsProvider.builder()
+        .stsClient(stsClient)
+        .refreshRequest(assumeRoleRequest)
+        .build();
+      
+      awsCredentialsProvider = provider;
     } else {
-      LOGGER.info("Using Role Based Access");
+      LOGGER.info("Using Default Credentials");
       awsCredentialsProvider = DefaultCredentialsProvider.create();
     }
 

--- a/airbyte-integrations/connectors/source-dynamodb/src/main/resources/spec.json
+++ b/airbyte-integrations/connectors/source-dynamodb/src/main/resources/spec.json
@@ -50,6 +50,15 @@
                 "type": "string",
                 "const": "Role",
                 "order": 0
+              },
+              "role_arn": {
+                "order": 1,
+                "title": "Role ARN",
+                "type": "string",
+                "description": "The ARN of the role to assume",
+                "default": "",
+                "airbyte_secret": true,
+                "examples": ["arn:aws:iam::123456789012:role/AirbyteRole"]
               }
             }
           }


### PR DESCRIPTION
To use, select role based authentication, and make sure the optional fields `Role ARN` and `Region` have a value

## TODO

- update version numbers as per airbyte PR bot
- figure out what to do about the sts client potentially requiring a region
- figure out what the `role-session-name` should be and whether this should be configurable through the UI?

Related to https://github.com/airbytehq/airbyte/issues/60944

## Resources

- https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/java_sts_code_examples.html
- https://stackoverflow.com/questions/62921548/aws-sdk-2-assume-role

## Building notes on a mac

```
brew install openjdk@21
./gradlew :airbyte-integrations:connectors:source-dynamodb:build
```
Grab the `docker buildx` command that is output, copy and paste to rerun the command adding `--build-arg platform=linux/amd64` to the end
```
docker buildx build <rest of command> --build-arg platform=linux/amd64
```
Then retag and push the image to ghcr so airbyte can download it.
```
docker image tag airbyte/source-dynamodb:dev ghcr.io/reidsy/airbyte-source-dynamodb:latest
docker push ghcr.io/reidsy/airbyte-source-dynamodb:latest
```

-------

## What
<!--
* Describe what the change is solving. Link all GitHub issues related to this change.
-->

## How
<!--
* Describe how code changes achieve the solution.
-->

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
